### PR TITLE
Program does not not kill off some threads upon closing under mono

### DIFF
--- a/crtcpl/Program.cs
+++ b/crtcpl/Program.cs
@@ -102,6 +102,13 @@ namespace crtcpl
             {
                 m.ReleaseMutex();
                 m.Dispose();
+                /*
+                 * With mono, there are some threads that remain when the application is closed
+                 * preventing the application from closing and causing to seem like it's hanging.
+                 * The two following calls remedy this.
+                 **/
+                Application.Exit();
+                System.Diagnostics.Process.GetCurrentProcess().Kill();
             }
         }
     }

--- a/crtcpl/Program.cs
+++ b/crtcpl/Program.cs
@@ -104,7 +104,7 @@ namespace crtcpl
                 m.Dispose();
                 /*
                  * With mono, there are some threads that remain when the application is closed
-                 * preventing the application from closing and causing to seem like it's hanging.
+                 * preventing the application from closing and causing it to seem like it's hanging.
                  * The two following calls remedy this.
                  **/
                 Application.Exit();


### PR DESCRIPTION
Added a couple of lines to kill any remaining threads that might be left after closing the application
when running under mono.