### PR TITLE
Opening serial port immediately after closing it throws an exception and causes the GUI to hang. Reordering Constants values to reflect IVAD property value

### DIFF
--- a/crtcpl/Constants.cs
+++ b/crtcpl/Constants.cs
@@ -3,24 +3,24 @@
     public static class Constants
     {
         public const int CONFIG_OFFSET_CONTRAST = 0;
-        public const int CONFIG_OFFSET_HORIZONTAL_POS = 1;
-        public const int CONFIG_OFFSET_HEIGHT = 2;
-        public const int CONFIG_OFFSET_VERTICAL_POS = 3;
-        public const int CONFIG_OFFSET_KEYSTONE = 4;
-        public const int CONFIG_OFFSET_PINCUSHION = 5;
-        public const int CONFIG_OFFSET_WIDTH = 6;
-        public const int CONFIG_OFFSET_PARALLELOGRAM = 7;
-        public const int CONFIG_OFFSET_BRIGHTNESS = 8;
-        public const int CONFIG_OFFSET_ROTATION = 9;
-        public const int CONFIG_OFFSET_RED = 10;
-        public const int CONFIG_OFFSET_GREEN = 11;
-        public const int CONFIG_OFFSET_BLUE = 12;
-        public const int CONFIG_OFFSET_RESERVED1 = 13;
-        public const int CONFIG_OFFSET_RESERVED2 = 14;
-        public const int CONFIG_OFFSET_RESERVED3 = 15;
-        public const int CONFIG_OFFSET_RESERVED4 = 16;
-        public const int CONFIG_OFFSET_RESERVED5 = 17;
-        public const int CONFIG_OFFSET_RESERVED6 = 18;
+        public const int CONFIG_OFFSET_RESERVED1 = 1;
+        public const int CONFIG_OFFSET_RESERVED2 = 2;
+        public const int CONFIG_OFFSET_RESERVED3 = 3;
+        public const int CONFIG_OFFSET_RED = 4;
+        public const int CONFIG_OFFSET_GREEN =5;
+        public const int CONFIG_OFFSET_BLUE = 6;
+        public const int CONFIG_OFFSET_HORIZONTAL_POS = 7;
+        public const int CONFIG_OFFSET_HEIGHT = 8;
+        public const int CONFIG_OFFSET_VERTICAL_POS = 9;
+        public const int CONFIG_OFFSET_RESERVED4 = 10;
+        public const int CONFIG_OFFSET_KEYSTONE = 11;
+        public const int CONFIG_OFFSET_PINCUSHION = 12;
+        public const int CONFIG_OFFSET_WIDTH = 13;
+        public const int CONFIG_OFFSET_RESERVED5 = 14;
+        public const int CONFIG_OFFSET_PARALLELOGRAM =15;
+        public const int CONFIG_OFFSET_RESERVED6 = 16;
+        public const int CONFIG_OFFSET_BRIGHTNESS = 17;
+        public const int CONFIG_OFFSET_ROTATION = 18;
         public const int CONFIG_OFFSET_CHECKSUM = 19;
 
         public const int IVAD_SETTING_CONTRAST = 0x00;

--- a/crtcpl/UCCom.cs
+++ b/crtcpl/UCCom.cs
@@ -93,7 +93,20 @@ namespace crtcpl
                     }
                     else
                     {
+                        /*Under mono an exception is thrown and the GUI hangsif the serial port is opened
+                         * immediately after closing it. It seems there are several threads
+                         * still waiting to die left over that are left from the previous 
+                         * serialport instance. Waiting from 5 to 10 seconds before opening
+                         * the port works but who has time to wait.....
+                         * This works with mono and it could be a temporary workaround
+                         * until understood better.
+                         */
+#if MONO
+                        goto done;
+#else
                         throw;
+#endif
+
                     }
                 }
 

--- a/crtcpl/UCCom.cs
+++ b/crtcpl/UCCom.cs
@@ -93,9 +93,9 @@ namespace crtcpl
                     }
                     else
                     {
-                        /*Under mono an exception is thrown and the GUI hangsif the serial port is opened
+                        /*Under mono an exception is thrown and the GUI hangs if the serial port is opened
                          * immediately after closing it. It seems there are several threads
-                         * still waiting to die left over that are left from the previous 
+                         * still waiting to die left over from the previous 
                          * serialport instance. Waiting from 5 to 10 seconds before opening
                          * the port works but who has time to wait.....
                          * This works with mono and it could be a temporary workaround


### PR DESCRIPTION
I don't know if this is an issue with dot net as well but this change makes closing and opening the serial port stable, at least with mono.

I can't get it to freeze now.
